### PR TITLE
remove build id from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: tabs
 channels:
   - conda-forge
 dependencies:
-  - rdkit=2023.09.4=py310hb79e901_0
+  - rdkit=2023.09.4
   - jupyter
   - ca-certificates
   - certifi


### PR DESCRIPTION
What we currently have will only create an environment on linux.
This fixes that.

Fixes #4 